### PR TITLE
[Discuss] How to deal with concurrent updates?

### DIFF
--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   build-depends:       base >= 4.7 && < 5
                      , mtl
+                     , extra
                      , transformers
                      , containers
                      , persistent

--- a/test/KisSpec.hs
+++ b/test/KisSpec.hs
@@ -9,6 +9,7 @@ import Kis
 import Control.Monad
 import Control.Monad.IO.Class
 import Database.Persist.Sqlite
+import Data.Maybe
 import Test.Hspec
 
 spec :: Spec
@@ -17,13 +18,32 @@ spec = do
         it "can be parametrized" $
             withKis (Kis kis) $
                 void $ req (CreatePatient "Thomas")
-    describe "withInMemoryKis" $
+    describe "withInMemoryKis" $ do
         it "can create a Patient" $
             withInMemoryKis $ do
                 pid <- req (CreatePatient "Thomas")
                 patient <- req (GetPatient pid)
                 liftIO $ liftM patientName patient `shouldBe` (Just "Thomas")
-
+        it "can place patient in bed" $
+            withInMemoryKis $ do
+                pat <- req (CreatePatient "Thomas")
+                bed <- req (CreateBed "xy")
+                patBed <- req (PlacePatient pat bed)
+                liftIO $ patBed `shouldSatisfy` isJust
+        -- Are the next two statements necessary? Should we always aim for a
+        -- consistent database or deal with inconsistencies like
+        -- patient-bed-relations of nonexisting entities? What happens when a
+        -- patient is assigned to a deleted bed?
+        it "can't place nonexisting patient in bed" $
+            withInMemoryKis $ do
+                bed <- req (CreateBed "xy")
+                patBed <- req (PlacePatient (toSqlKey 1) bed)
+                liftIO $ patBed `shouldSatisfy` isNothing
+        it "can't place patient in nonexisting bed" $
+            withInMemoryKis $ do
+                pat <- req (CreatePatient "xy")
+                patBed <- req (PlacePatient pat (toSqlKey 1))
+                liftIO $ patBed `shouldSatisfy` isNothing
 
 kis :: KisAction a -> KisClient IO a
 kis (CreatePatient _) = return (toSqlKey 1)


### PR DESCRIPTION
Habe hier beispielhaft Tests für PlacePatient geschrieben unter der Fragestellung, wie wir mit concurrent updates umgehen sollten. Was, wenn man z.B. im Web versucht einen Patienten in einem Bett zu platzieren, das schon wieder gelöscht wurde?
Sollen wir alle SQL-Insertions/Updates threadsafe machen? Meine Implementierung hier erfüllt das sicherlich nicht.
Was meint ihr @simonjantsch @loisch?