### PR TITLE
 [WIP] Add barebones spock application

### DIFF
--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -18,6 +18,9 @@ library
   build-depends:       base >= 4.7 && < 5
                      , mtl
                      , extra
+                     , Spock
+                     , wai-middleware-static
+                     , wai
                      , transformers
                      , containers
                      , persistent
@@ -35,6 +38,7 @@ library
                      , Kis.Kis
                      , Kis.Model
                      , Kis.SqlBackend
+                     , Web
   ghc-options:       -Wall -fwarn-incomplete-patterns
 
 executable kis-proto
@@ -50,15 +54,20 @@ test-suite kis-proto-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
+                     , bytestring
                      , kis-proto
                      , hspec
+                     , hspec-wai
                      , mtl
+                     , aeson
+                     , wai-extra
                      , transformers
                      , QuickCheck
                      , persistent-sqlite
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-incomplete-patterns
   default-language:    Haskell2010
   other-modules:       KisSpec
+                     , WebSpec
 
 source-repository head
   type:     git

--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -55,6 +55,7 @@ test-suite kis-proto-test
   main-is:             Spec.hs
   build-depends:       base
                      , bytestring
+                     , extra
                      , kis-proto
                      , hspec
                      , hspec-wai

--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   build-depends:       base >= 4.7 && < 5
                      , mtl
+                     , extra
                      , transformers
                      , containers
                      , persistent

--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -16,22 +16,19 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   build-depends:       base >= 4.7 && < 5
-                     , mtl
-                     , extra
-                     , Spock
-                     , wai-middleware-static
-                     , wai
-                     , transformers
                      , containers
+                     , esqueleto
+                     , extra
+                     , monad-logger
+                     , mtl
                      , persistent
                      , persistent-sqlite
                      , persistent-template
-                     , esqueleto
-                     , monad-logger
-                     , resourcet
+                     , Spock
                      , text
-                     , resource-pool
-                     , monad-control
+                     , transformers
+                     , wai
+                     , wai-middleware-static
   default-language:    Haskell2010
   exposed-modules:     App
                      , Kis
@@ -54,17 +51,16 @@ test-suite kis-proto-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
-                     , bytestring
+                     , aeson
                      , extra
-                     , kis-proto
                      , hspec
                      , hspec-wai
-                     , mtl
-                     , aeson
-                     , wai-extra
-                     , transformers
-                     , QuickCheck
+                     , kis-proto
+                     , persistent
                      , persistent-sqlite
+                     , QuickCheck
+                     , transformers
+                     , wai-extra
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-incomplete-patterns
   default-language:    Haskell2010
   other-modules:       KisSpec

--- a/src/App.hs
+++ b/src/App.hs
@@ -3,5 +3,7 @@ module App
     )
 where
 
+import Web
+
 appMain :: IO ()
-appMain = return ()
+appMain = webMain

--- a/src/Kis.hs
+++ b/src/Kis.hs
@@ -16,4 +16,6 @@ import Kis.SqlBackend
 import Control.Monad.RWS
 
 req :: Monad m => KisAction a -> KisClient m a
-req action = asks request >>= ($ action)
+req action = do
+    req' <- asks request
+    lift $ req' action

--- a/src/Kis/Kis.hs
+++ b/src/Kis/Kis.hs
@@ -21,7 +21,7 @@ import Kis.Model
 
 data KisAction a where
     CreateBed :: String -> KisAction BedId
-    CreatePatient :: String -> KisAction PatientId
+    CreatePatient :: Patient -> KisAction PatientId
     GetPatient :: PatientId -> KisAction (Maybe Patient)
     GetPatients :: KisAction [Entity Patient]
     PlacePatient :: PatientId -> BedId -> KisAction (Maybe PatientBedId)

--- a/src/Kis/Kis.hs
+++ b/src/Kis/Kis.hs
@@ -28,12 +28,12 @@ data KisAction a where
 
 deriving instance Show (KisAction a)
 
-data Kis m = Kis { request :: forall a. KisAction a -> KisClient m a }
-type KisClient m a = ReaderT (Kis m) m a
+data Kis m = Kis { request :: forall a. KisAction a -> m a }
+type KisClient m = ReaderT (Kis m) m
 
 -- withProductionKis - uses Postgresql, Logging, etc.
 
-withKis :: Kis m -> KisClient m () -> m ()
+withKis :: Kis m -> KisClient m a -> m a
 withKis kis action = runReaderT action kis
 
 _logShow :: (MonadLogger m, Show a) => Text -> a -> m ()

--- a/src/Kis/Model.hs
+++ b/src/Kis/Model.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -10,18 +11,18 @@ where
 import Database.Persist.TH
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
-Patient
+Patient json
     name String
-    deriving Show
+    deriving Show Eq
 Bed
     name String
-    deriving Show
+    deriving Show Eq
 
 PatientBed
     patientId PatientId
     bedId BedId
     UniquePatientId patientId
     UniqueBedId bedId
-    deriving Show
+    deriving Show Eq
 |]
 

--- a/src/Kis/SqlBackend.hs
+++ b/src/Kis/SqlBackend.hs
@@ -4,35 +4,51 @@
 {-# LANGUAGE RankNTypes                 #-}
 module Kis.SqlBackend
     ( withInMemoryKis
+    , inMemoryBackend
+    , runClient
     )
 where
 
 import Control.Monad.Extra
 import Control.Monad.IO.Class
 import Control.Monad.Logger
-import Control.Monad.RWS
 import Control.Monad.Trans.Control
 import Control.Monad.Trans.Reader
 import Database.Persist.Sql as S
 import Database.Persist.Sqlite
+import Database.Sqlite
 import Data.Maybe
 import qualified Database.Esqueleto as E
 
 import Kis.Model
 import Kis.Kis
 
-withInMemoryKis :: KisClient (NoLoggingT IO) () -> IO ()
+withInMemoryKis :: KisClient (NoLoggingT IO) a -> IO a
 withInMemoryKis client =
     runNoLoggingT $
     withSqliteConn ":memory:" $ \backend -> do
         void $ runSqlConn (runMigrationSilent migrateAll) backend
         withKis (Kis $ kis backend) client
     where
-        kis :: SqlBackend -> (forall a. KisAction a -> KisClient (NoLoggingT IO) a)
-        kis backend action = lift $ runSqlRequest action backend
+        kis :: SqlBackend -> (forall a. KisAction a -> NoLoggingT IO a)
+        kis backend action = runSqlRequest action backend
 
 runSqlRequest :: (MonadBaseControl IO m, MonadIO m, MonadLogger m) => KisAction a -> SqlBackend -> m a
 runSqlRequest req backend = runSqlConn (runAction req) backend
+
+runClient :: SqlBackend -> KisClient IO a -> IO a
+runClient backend client = do
+    runReaderT client (Kis kis)
+    where
+        kis :: forall a. KisAction a -> IO a
+        kis action = runSqlConn (runAction action) backend
+
+inMemoryBackend :: IO SqlBackend
+inMemoryBackend = do
+    connection <- open ":memory:"
+    backend <- wrapConnection connection (\_ _ _ _ -> return ())
+    void $ runSqlConn (runMigrationSilent migrateAll) backend
+    return backend
 
 runAction :: MonadIO m => KisAction a -> ReaderT SqlBackend m a
 runAction (CreateBed name) = S.insert (Bed name)

--- a/src/Kis/SqlBackend.hs
+++ b/src/Kis/SqlBackend.hs
@@ -52,7 +52,7 @@ inMemoryBackend = do
 
 runAction :: MonadIO m => KisAction a -> ReaderT SqlBackend m a
 runAction (CreateBed name) = S.insert (Bed name)
-runAction (CreatePatient name) = S.insert (Patient name)
+runAction (CreatePatient patient) = S.insert patient
 runAction (GetPatient pid) = S.get pid
 runAction GetPatients = getPatients
 runAction (PlacePatient patId bedId) =

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+module Web
+    ( webMain
+    , inMemoryApplication
+    )
+where
+
+import Control.Monad.RWS hiding (get)
+import Network.Wai.Middleware.Static
+import Network.Wai
+import Web.Spock.Safe
+
+import Kis
+import Kis.SqlBackend
+
+__ASSET_DIR__ :: FilePath
+__ASSET_DIR__ = "frontend"
+
+webMain :: IO ()
+webMain = runSpock 8080 inMemoryWeb
+
+web :: MonadIO m => (forall a. KisClient m a -> IO a) -> IO Middleware
+web runKisClient =
+    spockT runKisClient webInterface
+
+inMemoryWeb :: IO Middleware
+inMemoryWeb = do
+    backend <- inMemoryBackend
+    web (runClient backend)
+
+inMemoryApplication :: IO Application
+inMemoryApplication = spockAsApp inMemoryWeb
+
+webInterface :: MonadIO m => SpockT (KisClient m) ()
+webInterface = do
+    middleware $ staticPolicy $ addBase __ASSET_DIR__
+    post ("/patient" <//> var) $ \name -> do
+        patId <- lift $ req (CreatePatient name)
+        json patId
+    get "/patients" $ do
+        patients <- lift $ req GetPatients
+        json patients

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -35,9 +35,11 @@ inMemoryApplication = spockAsApp inMemoryWeb
 webInterface :: MonadIO m => SpockT (KisClient m) ()
 webInterface = do
     middleware $ staticPolicy $ addBase __ASSET_DIR__
-    post ("/patient" <//> var) $ \name -> do
-        patId <- lift $ req (CreatePatient name)
+    post "/patient" $ do
+        patient <- jsonBody'
+        patId <- req' (CreatePatient patient)
         json patId
     get "/patients" $ do
-        patients <- lift $ req GetPatients
+        patients <- req' GetPatients
         json patients
+    where req' = lift . req

--- a/test/KisSpec.hs
+++ b/test/KisSpec.hs
@@ -17,16 +17,16 @@ spec = do
     describe "withKis" $
         it "can be parametrized" $
             withKis (Kis kis) $
-                void $ req (CreatePatient "Thomas")
+                void $ req (CreatePatient $ Patient "Thomas")
     describe "withInMemoryKis" $ do
         it "can create a Patient" $
             withInMemoryKis $ do
-                pid <- req (CreatePatient "Thomas")
+                pid <- req (CreatePatient $ Patient "Thomas")
                 patient <- req (GetPatient pid)
                 liftIO $ liftM patientName patient `shouldBe` (Just "Thomas")
         it "can place patient in bed" $
             withInMemoryKis $ do
-                pat <- req (CreatePatient "Thomas")
+                pat <- req (CreatePatient $ Patient "Thomas")
                 bed <- req (CreateBed "xy")
                 patBed <- req (PlacePatient pat bed)
                 liftIO $ patBed `shouldSatisfy` isJust
@@ -41,7 +41,7 @@ spec = do
                 liftIO $ patBed `shouldSatisfy` isNothing
         it "can't place patient in nonexisting bed" $
             withInMemoryKis $ do
-                pat <- req (CreatePatient "xy")
+                pat <- req (CreatePatient $ Patient "xy")
                 patBed <- req (PlacePatient pat (toSqlKey 1))
                 liftIO $ patBed `shouldSatisfy` isNothing
 

--- a/test/KisSpec.hs
+++ b/test/KisSpec.hs
@@ -45,7 +45,7 @@ spec = do
                 patBed <- req (PlacePatient pat (toSqlKey 1))
                 liftIO $ patBed `shouldSatisfy` isNothing
 
-kis :: KisAction a -> KisClient IO a
+kis :: KisAction a -> IO a
 kis (CreatePatient _) = return (toSqlKey 1)
 kis _ = undefined
 

--- a/test/KisSpec.hs
+++ b/test/KisSpec.hs
@@ -9,6 +9,7 @@ import Kis
 import Control.Monad
 import Control.Monad.IO.Class
 import Database.Persist.Sqlite
+import Data.Maybe
 import Test.Hspec
 
 spec :: Spec
@@ -17,13 +18,32 @@ spec = do
         it "can be parametrized" $
             withKis (Kis kis) $
                 void $ req (CreatePatient "Thomas")
-    describe "withInMemoryKis" $
+    describe "withInMemoryKis" $ do
         it "can create a Patient" $
             withInMemoryKis $ do
                 pid <- req (CreatePatient "Thomas")
                 patient <- req (GetPatient pid)
                 liftIO $ liftM patientName patient `shouldBe` (Just "Thomas")
-
+        it "can place patient in bed" $
+            withInMemoryKis $ do
+                pat <- req (CreatePatient "Thomas")
+                bed <- req (CreateBed "xy")
+                patBed <- req (PlacePatient pat bed)
+                liftIO $ patBed `shouldSatisfy` isJust
+        -- Are the next two statements necessary? Should we always aim for a
+        -- consistent database or deal with inconsistencies like
+        -- patient-bed-relations of nonexisting entities? What happens when a
+        -- patient is assigned to a deleted bed?
+        it "can't place nonexisting patient in bed" $
+            withInMemoryKis $ do
+                bed <- req (CreateBed "xy")
+                patBed <- req (PlacePatient (toSqlKey 1) bed)
+                liftIO $ patBed `shouldSatisfy` isNothing
+        it "can't place patient in nonexisting bed" $
+            withInMemoryKis $ do
+                pat <- req (CreatePatient "xy")
+                patBed <- req (PlacePatient pat (toSqlKey 1))
+                liftIO $ patBed `shouldSatisfy` isNothing
 
 kis :: KisAction a -> KisClient IO a
 kis (CreatePatient _) = return (toSqlKey 1)

--- a/test/WebSpec.hs
+++ b/test/WebSpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+module WebSpec
+    ( spec
+    )
+where
+
+import Web
+
+import Test.Hspec hiding (pending)
+import Test.Hspec.Wai
+import Data.Monoid
+import Data.Aeson
+import Control.Monad
+import Network.Wai.Test
+import Kis.Model
+import Database.Persist hiding (get)
+
+spec :: Spec
+spec =
+    with inMemoryApplication $
+        describe "Fresh inMemoryApplication" $ do
+            it "starts with empty list of patients" $
+                get "/patients" `shouldDecodeTo` ([] :: [Entity Patient])
+            it "can create a patient" $ do
+                let name = "Thomas"
+                patId <- shouldDecode $ post ("/patient/" <> name) ""
+                get "/patients" `shouldDecodeTo` [Entity patId (Patient "Thomas")]
+
+shouldDecode :: FromJSON a => WaiSession SResponse -> WaiSession a
+shouldDecode a = do
+    x <- liftM (eitherDecode . simpleBody) a
+    either error return x
+
+shouldDecodeTo :: (Eq b, Show b, FromJSON b) => WaiSession SResponse -> b -> WaiExpectation
+shouldDecodeTo a b = do
+    x <- shouldDecode a
+    liftIO $ x `shouldBe` b


### PR DESCRIPTION
`Test.Hspec.Wai` aus `hspec-wai` bzw. `Network.Wai.Test` aus `wai-extra` ermöglichen es Wai-Applications direkt ohne HTTP-Schnittstelle zu testen. Das könnte auch für diverse bestehende KisTests des SimpleHospitalSim sehr praktisch sein. Insbesondere braucht man keinen freien Port und möglicherweise sind die Tests so auch noch etwas schneller.