### PR TITLE
[RDY] Error handling

### DIFF
--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -17,7 +17,10 @@ library
   hs-source-dirs:      src
   build-depends:       base >= 4.7 && < 5
                      , containers
+                     , either
+                     , monad-control
                      , esqueleto
+                     , exceptions
                      , extra
                      , monad-logger
                      , mtl
@@ -56,10 +59,12 @@ test-suite kis-proto-test
   main-is:             Spec.hs
   build-depends:       base
                      , aeson
+                     , either
                      , extra
                      , hspec
                      , hspec-wai
                      , kis-proto
+                     , mtl
                      , persistent
                      , persistent-sqlite
                      , QuickCheck

--- a/src/Kis.hs
+++ b/src/Kis.hs
@@ -3,6 +3,7 @@ module Kis
     , KisConfig(..)
     , KisClient
     , Kis(..)
+    , KisException(..)
     , waitForKisTime
     , withInMemoryKis
     , withKis

--- a/src/Kis/Kis.hs
+++ b/src/Kis/Kis.hs
@@ -9,14 +9,16 @@ module Kis.Kis
     , KisClient
     , KisConfig(..)
     , Kis(..)
+    , KisException(..)
     )
 where
 
 import Control.Monad.Logger
 import Control.Monad.RWS hiding (asks)
-import Control.Monad.Trans.Reader
+import Control.Monad.Reader
 import Database.Persist
 import Data.Text
+import GHC.Exception
 
 import Kis.Model
 import Kis.Time
@@ -39,9 +41,14 @@ type KisClient m = ReaderT (Kis m) m
 
 data KisConfig = KisConfig Clock
 
--- withProductionKis - uses Postgresql, Logging, etc.
+data KisException =
+    ConstraintViolation
+    | OtherError Text
+    deriving (Show, Eq)
 
-withKis :: Kis m -> KisClient m a -> m a
+instance Exception KisException
+
+withKis :: Monad m => Kis m -> KisClient m a -> m a
 withKis kis action = runReaderT action kis
 
 _logShow :: (MonadLogger m, Show a) => Text -> a -> m ()

--- a/src/Kis/SqlBackend.hs
+++ b/src/Kis/SqlBackend.hs
@@ -10,12 +10,15 @@ module Kis.SqlBackend
 where
 
 import Control.Monad.Extra
-import Control.Monad.IO.Class
+import Control.Monad.Except
 import Control.Monad.Trans.Reader
+import Control.Monad.Trans.Control
+import Control.Monad.Catch
 import Database.Persist.Sql as S
 import Database.Persist.Sqlite
 import Database.Sqlite as Sqlite hiding (config)
 import qualified Database.Esqueleto as E
+import qualified Data.Text as T
 
 import Kis.Model
 import Kis.Kis
@@ -24,27 +27,36 @@ withInMemoryKis :: KisConfig -> KisClient IO a -> IO a
 withInMemoryKis config client =
     inMemoryBackend >>= \backend -> runClient backend config client
 
-runClient :: SqlBackend -> KisConfig -> KisClient IO a -> IO a
+runClient :: (MonadCatch m, MonadBaseControl IO m, MonadIO m)
+          => SqlBackend -> KisConfig -> KisClient m a -> m a
 runClient backend (KisConfig clock) client =
     runReaderT client (Kis (handleKisRequest backend) clock)
 
-handleKisRequest :: SqlBackend -> forall a. KisAction a -> IO a
-handleKisRequest backend req = runSqlConn (runAction req) backend
+handleKisRequest :: (MonadCatch m, MonadBaseControl IO m, MonadIO m) =>
+    SqlBackend -> forall a. KisAction a -> m a
+handleKisRequest backend req = runSqlConn (convertSqliteException $ runAction req) backend
 
-inMemoryBackend :: IO SqlBackend
-inMemoryBackend = do
+convertSqliteException :: MonadCatch m => m a -> m a
+convertSqliteException = handle sqliteExceptions
+    where
+      sqliteExceptions (SqliteException ErrorConstraint _ _) = throwM ConstraintViolation
+      sqliteExceptions (SqliteException errorType _ _) = throwM (OtherError (T.pack . show $ errorType))
+
+inMemoryBackend :: MonadIO m => m SqlBackend
+inMemoryBackend = liftIO $ do
     connection <- Sqlite.open ":memory:"
     void $ Sqlite.step =<< Sqlite.prepare connection "PRAGMA foreign_keys = ON;"
     backend <- wrapConnection connection (\_ _ _ _ -> return ())
     void $ runSqlConn (runMigrationSilent migrateAll) backend
     return backend
 
-runAction :: MonadIO m => KisAction a -> ReaderT SqlBackend m a
+runAction :: (MonadCatch m, MonadIO m)
+          => KisAction a -> ReaderT SqlBackend m a
 runAction (CreateBed name) = S.insert (Bed name)
 runAction (CreatePatient patient) = S.insert patient
 runAction (GetPatient pid) = S.get pid
 runAction GetPatients = getPatients
-runAction (PlacePatient patId bedId) = S.insertUnique $ PatientBed patId bedId
+runAction (PlacePatient patId bedId) = S.insertUnique (PatientBed patId bedId)
 
 getPatients :: MonadIO m => ReaderT SqlBackend m [Entity Patient]
 getPatients = E.select $ E.from $ \p -> return p

--- a/src/Kis/SqlBackend.hs
+++ b/src/Kis/SqlBackend.hs
@@ -14,8 +14,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Reader
 import Database.Persist.Sql as S
 import Database.Persist.Sqlite
-import Database.Sqlite hiding (config)
-import Data.Maybe
+import Database.Sqlite as Sqlite hiding (config)
 import qualified Database.Esqueleto as E
 
 import Kis.Model
@@ -34,7 +33,8 @@ handleKisRequest backend req = runSqlConn (runAction req) backend
 
 inMemoryBackend :: IO SqlBackend
 inMemoryBackend = do
-    connection <- open ":memory:"
+    connection <- Sqlite.open ":memory:"
+    void $ Sqlite.step =<< Sqlite.prepare connection "PRAGMA foreign_keys = ON;"
     backend <- wrapConnection connection (\_ _ _ _ -> return ())
     void $ runSqlConn (runMigrationSilent migrateAll) backend
     return backend
@@ -44,16 +44,7 @@ runAction (CreateBed name) = S.insert (Bed name)
 runAction (CreatePatient patient) = S.insert patient
 runAction (GetPatient pid) = S.get pid
 runAction GetPatients = getPatients
-runAction (PlacePatient patId bedId) =
-    ifM (exists patId &&^ exists bedId) -- Not thread safe.
-        (S.insertUnique $ PatientBed patId bedId)
-        (return Nothing)
-
-exists ::
-    (PersistEntity val, MonadIO m,
-      PersistStore (PersistEntityBackend val)) =>
-     Key val -> ReaderT (PersistEntityBackend val) m Bool
-exists key = liftM isJust (S.get key)
+runAction (PlacePatient patId bedId) = S.insertUnique $ PatientBed patId bedId
 
 getPatients :: MonadIO m => ReaderT SqlBackend m [Entity Patient]
 getPatients = E.select $ E.from $ \p -> return p

--- a/src/Simulator/Template.hs
+++ b/src/Simulator/Template.hs
@@ -15,10 +15,10 @@ newtype SimulatorAction m a = SimulatorAction (a -> KisClient m a)
 
 data Template m a = Template [(SimulatorAction m a, TimeOffset)]
 
-__template1__ :: (MonadIO m) => Template m (PatientId, BedId)
+__template1__ :: MonadIO m => Template m (PatientId, BedId)
 __template1__ = Template [ (SimulatorAction movePatient, TimeOffset 10) ]
 
-movePatient :: (MonadIO m) => (PatientId, BedId) -> KisClient m (PatientId, BedId)
+movePatient :: MonadIO m => (PatientId, BedId) -> KisClient m (PatientId, BedId)
 movePatient (patientId, _) =
     do bedId <- req (CreateBed "someBed")
        void $ req (PlacePatient patientId bedId)


### PR DESCRIPTION
Ich wandle momentan einfach die `SqliteException`s in `KisException`s um, damit die Exceptions unabhängig vom verwendeten Backend sind.
Der Benutzer der Api (also Web/Simulator) kann dann die Exceptions abfangen / in generische Meldungen umwandeln. Jedenfalls glaube ich nicht, dass wir diese Fehler in die Rückgabe-Typen von KisRequests einbauen müssen. Ich denke es macht schon Sinn, wenn "PlacePatient" eine Exception raised, wenn man Daten eingegeben hat, die Constraints verletzen.