### PR TITLE
[RDY] refactored backend API

### DIFF
--- a/src/Kis.hs
+++ b/src/Kis.hs
@@ -7,8 +7,9 @@ module Kis
     , waitForKisTime
     , withSqliteKis
     , SqliteBackendType(..)
-    , withKis
     , req
+    , runClient
+    , runSingleClientSqlite
     , module Kis.Model
     )
 where

--- a/src/Kis/Kis.hs
+++ b/src/Kis/Kis.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 
 module Kis.Kis
-    ( withKis
-    , KisRequest(..)
+    ( KisRequest(..)
     , KisClient
     , KisConfig(..)
     , Kis(..)
@@ -47,9 +46,6 @@ data KisException =
     deriving (Show, Eq)
 
 instance Exception KisException
-
-withKis :: Monad m => Kis m -> KisClient m a -> m a
-withKis kis action = runReaderT action kis
 
 _logShow :: (MonadLogger m, Show a) => Text -> a -> m ()
 _logShow tag x = logInfoN (tag <> ": " <> (pack . show $ x))

--- a/src/Simulator/Sim.hs
+++ b/src/Simulator/Sim.hs
@@ -9,7 +9,6 @@ import Control.Monad.IO.Class
 import Data.Time.Clock
 
 import Kis
-import Kis.SqliteBackend
 import Kis.Time
 import Simulator.Template
 
@@ -31,8 +30,7 @@ runSimulator template =
 simMain :: IO ()
 simMain =
     do now <- getCurrentTime
-       backend <- sqliteBackend InMemory
        let kisConfig = KisConfig (virtualTimeClock now multiplier)
-       runClient backend kisConfig (runSimulator __template1__)
+       runSingleClientSqlite InMemory kisConfig (runSimulator __template1__)
     where
       multiplier = 2

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -28,7 +28,8 @@ web runKisClient =
 inMemoryWeb :: IO Middleware
 inMemoryWeb = do
     backend <- sqliteBackend InMemory
-    web (runClient backend (KisConfig realTimeClock))
+    let kis = buildKisWithBackend backend (KisConfig realTimeClock)
+    web (runClient kis)
 
 inMemoryApplication :: IO Application
 inMemoryApplication = spockAsApp inMemoryWeb


### PR DESCRIPTION
Habe die Functionen WithInMemoryKis und runClient verändert. runClient nimmt jetzt ein fertiges Kis und lässt es nur laufen. WithInMemoryKis baut erst ein Kis auf und stellt es dann zu verfügung. Wenn man einen KisClient laufen lassen will, muss man immernoch runClient aufrufen. 

Für den Fall, dass man nur einen Client laufen lässt, gibt es jetzt runSingleClient, welches im Prinzip WithInMemoryKis macht und dann den Client mit dem gebauten Kis laufen lässt. Ob die Namensgebung gut ist weiss ich nicht genau.

Ausserdem gibt es buildKisWithBackend, was von WithInMemoryKis benutzt wird um das Kis zu bauen. Exportiert werden muss es jetzt nur wegen dem Web Usecase.

Finde, dass die Funktionen so besser aufeinander aufbauen und nicht dasselbe tun. Ausserdem glaube ich, dass es besser geeignet ist um mehrere Module in Threads zu starten und auch für meine ReadOnly Ideen.