### PR TITLE
[WIP] added Readonly Mode in Kis

### DIFF
--- a/kis-proto.cabal
+++ b/kis-proto.cabal
@@ -39,6 +39,7 @@ library
                      , Kis
                      , Kis.Kis
                      , Kis.Model
+                     , Kis.ReadOnly
                      , Kis.SqlBackend
                      , Kis.SqliteBackend
                      , Kis.Time

--- a/src/Kis.hs
+++ b/src/Kis.hs
@@ -1,9 +1,16 @@
 module Kis
-    ( KisRequest(..)
+    ( KisRequest
+    , KisWriteRequest(..)
+    , KisReadRequest(..)
     , KisConfig(..)
     , KisClient
     , Kis(..)
     , KisException(..)
+    , createPatient
+    , createBed
+    , placePatient
+    , getPatient
+    , getPatients
     , waitForKisTime
     , withSqliteKis
     , SqliteBackendType(..)

--- a/src/Kis/ReadOnly.hs
+++ b/src/Kis/ReadOnly.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Kis.ReadOnly
-    ( runReadOnlyClient
+    ( req
+    , runReadOnlyClient
     , KisReadOnlyClient
     )
 where
@@ -13,7 +14,7 @@ import Kis.Time
 
 data ReadOnlyKis m =
     ReadOnlyKis
-    { _rok_requestHandler :: forall a. KisReadRequest a -> m a
+    { rok_requestHandler :: forall a. KisReadRequest a -> m a
     , _rok_clock :: Clock
     }
 
@@ -27,4 +28,9 @@ toReadOnlyKis :: Kis m -> ReadOnlyKis m
 toReadOnlyKis (Kis reqHandler clock) =
     ReadOnlyKis roRequestHandler clock
     where
-      roRequestHandler action = reqHandler (Right action)
+      roRequestHandler request = reqHandler (Right request)
+
+req :: Monad m => KisReadRequest a -> KisReadOnlyClient m a
+req request =
+    do reqH <- asks rok_requestHandler
+       lift $ reqH request

--- a/src/Kis/ReadOnly.hs
+++ b/src/Kis/ReadOnly.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Kis.ReadOnly
+    ( runReadOnlyClient
+    , KisReadOnlyClient
+    )
+where
+
+import Control.Monad.Reader
+
+import Kis.Kis
+import Kis.Time
+
+data ReadOnlyKis m =
+    ReadOnlyKis
+    { _rok_requestHandler :: forall a. KisReadRequest a -> m a
+    , _rok_clock :: Clock
+    }
+
+type KisReadOnlyClient m = ReaderT (ReadOnlyKis m) m
+
+runReadOnlyClient :: Kis m -> KisReadOnlyClient m a -> m a
+runReadOnlyClient kis readOnlyClient =
+    runReaderT readOnlyClient (toReadOnlyKis kis)
+
+toReadOnlyKis :: Kis m -> ReadOnlyKis m
+toReadOnlyKis (Kis reqHandler clock) =
+    ReadOnlyKis roRequestHandler clock
+    where
+      roRequestHandler action = reqHandler (Right action)

--- a/src/Simulator/Sim.hs
+++ b/src/Simulator/Sim.hs
@@ -16,8 +16,8 @@ import Simulator.Template
 
 runSimulator :: MonadIO m => Template m (PatientId, BedId) -> KisClient m ()
 runSimulator template =
-  do patientId <- req (CreatePatient (Patient "Simon"))
-     bedId <- req (CreateBed "1a")
+  do patientId <- req (createPatient (Patient "Simon"))
+     bedId <- req (createBed "1a")
      loop template (patientId, bedId)
        where
          loop template' templateInfo =

--- a/src/Simulator/Template.hs
+++ b/src/Simulator/Template.hs
@@ -20,6 +20,6 @@ __template1__ = Template [ (SimulatorAction movePatient, TimeOffset 10) ]
 
 movePatient :: MonadIO m => (PatientId, BedId) -> KisClient m (PatientId, BedId)
 movePatient (patientId, _) =
-    do bedId <- req (CreateBed "someBed")
-       void $ req (PlacePatient patientId bedId)
+    do bedId <- req (createBed "someBed")
+       void $ req (placePatient patientId bedId)
        return (patientId, bedId)

--- a/src/Web.hs
+++ b/src/Web.hs
@@ -38,9 +38,9 @@ webInterface = do
     middleware $ staticPolicy $ addBase __ASSET_DIR__
     post "/patient" $ do
         patient <- jsonBody'
-        patId <- req' (CreatePatient patient)
+        patId <- req' (createPatient patient)
         json patId
     get "/patients" $ do
-        patients <- req' GetPatients
+        patients <- req' getPatients
         json patients
     where req' = lift . req

--- a/test/KisSpec.hs
+++ b/test/KisSpec.hs
@@ -19,18 +19,18 @@ spec = do
     describe "withKis" $
         it "can be parametrized" $
             withKis (Kis kis realTimeClock) $
-                void $ req (CreatePatient $ Patient "Thomas")
+                void $ req (createPatient $ Patient "Thomas")
     describe "withInMemoryKis" $ do
         it "can create a Patient" $
             withSqliteKis InMemory kisConfig $ do
-                pid <- req (CreatePatient $ Patient "Thomas")
-                patient <- req (GetPatient pid)
+                pid <- req (createPatient $ Patient "Thomas")
+                patient <- req (getPatient pid)
                 liftIO $ liftM patientName patient `shouldBe` (Just "Thomas")
         it "can place patient in bed" $
             withSqliteKis InMemory kisConfig $ do
-                pat <- req (CreatePatient $ Patient "Thomas")
-                bed <- req (CreateBed "xy")
-                patBed <- req (PlacePatient pat bed)
+                pat <- req (createPatient $ Patient "Thomas")
+                bed <- req (createBed "xy")
+                patBed <- req (placePatient pat bed)
                 liftIO $ patBed `shouldSatisfy` isJust
         -- Are the next two statements necessary? Should we always aim for a
         -- consistent database or deal with inconsistencies like
@@ -38,17 +38,17 @@ spec = do
         -- patient is assigned to a deleted bed?
         it "can't place nonexisting patient in bed" $
             (withSqliteKis InMemory kisConfig $ do
-                bed <- req (CreateBed "xy")
-                void $ req (PlacePatient (toSqlKey 1) bed))
+                bed <- req (createBed "xy")
+                void $ req (placePatient (toSqlKey 1) bed))
             `shouldThrow` (== ConstraintViolation)
         it "can't place patient in nonexisting bed" $
             (withSqliteKis InMemory kisConfig $ do
-                pat <- req (CreatePatient $ Patient "xy")
-                void $ req (PlacePatient pat (toSqlKey 1)))
+                pat <- req (createPatient $ Patient "xy")
+                void $ req (placePatient pat (toSqlKey 1)))
             `shouldThrow` (== ConstraintViolation)
 
 kis :: KisRequest a -> IO a
-kis (CreatePatient _) = return (toSqlKey 1)
+kis (Left (CreatePatient _)) = return (toSqlKey 1)
 kis _ = undefined
 
 kisConfig :: KisConfig


### PR DESCRIPTION
Mit dieser Version ist auf Typebene sichergestellt, dass in einem KisReadOnlyClient nur Read Operationen gemacht werden. Mit runReadOnlyClient kann man einen KisReadOnlyClient, also einen KisClient in dem nur Reads vorkommen, mit einem normalen Kis laufen lassen, das würde sich dann das Backend zB. teilen mit anderen Clients.

Leider ist es nicht ganz elegant modelliert, aber ich habe länger gesucht und nicht gefunden, wie ich es besser machen kann.